### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/diff.txt
+++ b/diff.txt
@@ -1,308 +1,696 @@
+diff --git a/diff.txt b/diff.txt
+index 4f6a4a5..e69de29 100644
+--- a/diff.txt
++++ b/diff.txt
+@@ -1,308 +0,0 @@
+-diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+-index 94085da..2e93e98 100644
+---- a/pnpm-lock.yaml
+-+++ b/pnpm-lock.yaml
+-@@ -134,20 +134,20 @@ packages:
+-       - jsonschema
+-       - semver
+- 
+--  '@babel/code-frame@7.26.0':
+--    resolution: {integrity: sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==}
+-+  '@babel/code-frame@7.26.2':
+-+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
+-     engines: {node: '>=6.9.0'}
+- 
+--  '@babel/compat-data@7.26.0':
+--    resolution: {integrity: sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==}
+-+  '@babel/compat-data@7.26.2':
+-+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
+-     engines: {node: '>=6.9.0'}
+- 
+-   '@babel/core@7.26.0':
+-     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+-     engines: {node: '>=6.9.0'}
+- 
+--  '@babel/generator@7.26.0':
+--    resolution: {integrity: sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==}
+-+  '@babel/generator@7.26.2':
+-+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
+-     engines: {node: '>=6.9.0'}
+- 
+-   '@babel/helper-compilation-targets@7.25.9':
+-@@ -184,8 +184,8 @@ packages:
+-     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
+-     engines: {node: '>=6.9.0'}
+- 
+--  '@babel/parser@7.26.1':
+--    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
+-+  '@babel/parser@7.26.2':
+-+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+-     engines: {node: '>=6.0.0'}
+-     hasBin: true
+- 
+-@@ -507,8 +507,8 @@ packages:
+-   '@sinonjs/fake-timers@10.3.0':
+-     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+- 
+--  '@stylistic/eslint-plugin@2.9.0':
+--    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
+-+  '@stylistic/eslint-plugin@2.10.0':
+-+    resolution: {integrity: sha512-neWEgjp0qKxutbrKac5g23V5LX2c2Clyiz3zFxxybY8VSMfr+MmvwM204zg8YFbe9n2zcTwkpppCL2luwYcMhg==}
+-     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+-     peerDependencies:
+-       eslint: '>=8.40.0'
+-@@ -922,8 +922,8 @@ packages:
+-   convert-source-map@2.0.0:
+-     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+- 
+--  core-js-compat@3.38.1:
+--    resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+-+  core-js-compat@3.39.0:
+-+    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
+- 
+-   create-jest@29.7.0:
+-     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+-@@ -2494,8 +2494,8 @@ packages:
+-     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
+-     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+- 
+--  ts-api-utils@1.3.0:
+--    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+-+  ts-api-utils@1.4.0:
+-+    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
+-     engines: {node: '>=16'}
+-     peerDependencies:
+-       typescript: '>=4.2.0'
+-@@ -2720,7 +2720,7 @@ snapshots:
+-       '@clack/prompts': 0.7.0
+-       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.13.0)
+-       '@eslint/markdown': 6.2.1
+--      '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0)(typescript@5.6.3)
+-+      '@stylistic/eslint-plugin': 2.10.0(eslint@9.13.0)(typescript@5.6.3)
+-       '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
+-       '@typescript-eslint/parser': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
+-       '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
+-@@ -2775,23 +2775,23 @@ snapshots:
+- 
+-   '@aws-cdk/cloud-assembly-schema@38.0.1': {}
+- 
+--  '@babel/code-frame@7.26.0':
+-+  '@babel/code-frame@7.26.2':
+-     dependencies:
+-       '@babel/helper-validator-identifier': 7.25.9
+-       js-tokens: 4.0.0
+-       picocolors: 1.1.1
+- 
+--  '@babel/compat-data@7.26.0': {}
+-+  '@babel/compat-data@7.26.2': {}
+- 
+-   '@babel/core@7.26.0':
+-     dependencies:
+-       '@ampproject/remapping': 2.3.0
+--      '@babel/code-frame': 7.26.0
+--      '@babel/generator': 7.26.0
+-+      '@babel/code-frame': 7.26.2
+-+      '@babel/generator': 7.26.2
+-       '@babel/helper-compilation-targets': 7.25.9
+-       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+-       '@babel/helpers': 7.26.0
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@babel/template': 7.25.9
+-       '@babel/traverse': 7.25.9
+-       '@babel/types': 7.26.0
+-@@ -2803,9 +2803,9 @@ snapshots:
+-     transitivePeerDependencies:
+-       - supports-color
+- 
+--  '@babel/generator@7.26.0':
+-+  '@babel/generator@7.26.2':
+-     dependencies:
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@babel/types': 7.26.0
+-       '@jridgewell/gen-mapping': 0.3.5
+-       '@jridgewell/trace-mapping': 0.3.25
+-@@ -2813,7 +2813,7 @@ snapshots:
+- 
+-   '@babel/helper-compilation-targets@7.25.9':
+-     dependencies:
+--      '@babel/compat-data': 7.26.0
+-+      '@babel/compat-data': 7.26.2
+-       '@babel/helper-validator-option': 7.25.9
+-       browserslist: 4.24.2
+-       lru-cache: 5.1.1
+-@@ -2848,7 +2848,7 @@ snapshots:
+-       '@babel/template': 7.25.9
+-       '@babel/types': 7.26.0
+- 
+--  '@babel/parser@7.26.1':
+-+  '@babel/parser@7.26.2':
+-     dependencies:
+-       '@babel/types': 7.26.0
+- 
+-@@ -2939,15 +2939,15 @@ snapshots:
+- 
+-   '@babel/template@7.25.9':
+-     dependencies:
+--      '@babel/code-frame': 7.26.0
+--      '@babel/parser': 7.26.1
+-+      '@babel/code-frame': 7.26.2
+-+      '@babel/parser': 7.26.2
+-       '@babel/types': 7.26.0
+- 
+-   '@babel/traverse@7.25.9':
+-     dependencies:
+--      '@babel/code-frame': 7.26.0
+--      '@babel/generator': 7.26.0
+--      '@babel/parser': 7.26.1
+-+      '@babel/code-frame': 7.26.2
+-+      '@babel/generator': 7.26.2
+-+      '@babel/parser': 7.26.2
+-       '@babel/template': 7.25.9
+-       '@babel/types': 7.26.0
+-       debug: 4.3.7
+-@@ -3278,7 +3278,7 @@ snapshots:
+-     dependencies:
+-       '@sinonjs/commons': 3.0.1
+- 
+--  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
+-+  '@stylistic/eslint-plugin@2.10.0(eslint@9.13.0)(typescript@5.6.3)':
+-     dependencies:
+-       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
+-       eslint: 9.13.0
+-@@ -3300,7 +3300,7 @@ snapshots:
+- 
+-   '@types/babel__core@7.20.5':
+-     dependencies:
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@babel/types': 7.26.0
+-       '@types/babel__generator': 7.6.8
+-       '@types/babel__template': 7.4.4
+-@@ -3312,7 +3312,7 @@ snapshots:
+- 
+-   '@types/babel__template@7.4.4':
+-     dependencies:
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@babel/types': 7.26.0
+- 
+-   '@types/babel__traverse@7.20.6':
+-@@ -3384,7 +3384,7 @@ snapshots:
+-       graphemer: 1.4.0
+-       ignore: 5.3.2
+-       natural-compare: 1.4.0
+--      ts-api-utils: 1.3.0(typescript@5.6.3)
+-+      ts-api-utils: 1.4.0(typescript@5.6.3)
+-     optionalDependencies:
+-       typescript: 5.6.3
+-     transitivePeerDependencies:
+-@@ -3413,7 +3413,7 @@ snapshots:
+-       '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
+-       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
+-       debug: 4.3.7
+--      ts-api-utils: 1.3.0(typescript@5.6.3)
+-+      ts-api-utils: 1.4.0(typescript@5.6.3)
+-     optionalDependencies:
+-       typescript: 5.6.3
+-     transitivePeerDependencies:
+-@@ -3431,7 +3431,7 @@ snapshots:
+-       is-glob: 4.0.3
+-       minimatch: 9.0.5
+-       semver: 7.6.3
+--      ts-api-utils: 1.3.0(typescript@5.6.3)
+-+      ts-api-utils: 1.4.0(typescript@5.6.3)
+-     optionalDependencies:
+-       typescript: 5.6.3
+-     transitivePeerDependencies:
+-@@ -3462,7 +3462,7 @@ snapshots:
+- 
+-   '@vue/compiler-core@3.5.12':
+-     dependencies:
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@vue/shared': 3.5.12
+-       entities: 4.5.0
+-       estree-walker: 2.0.2
+-@@ -3475,7 +3475,7 @@ snapshots:
+- 
+-   '@vue/compiler-sfc@3.5.12':
+-     dependencies:
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@vue/compiler-core': 3.5.12
+-       '@vue/compiler-dom': 3.5.12
+-       '@vue/compiler-ssr': 3.5.12
+-@@ -3756,7 +3756,7 @@ snapshots:
+- 
+-   convert-source-map@2.0.0: {}
+- 
+--  core-js-compat@3.38.1:
+-+  core-js-compat@3.39.0:
+-     dependencies:
+-       browserslist: 4.24.2
+- 
+-@@ -4143,7 +4143,7 @@ snapshots:
+-       '@eslint-community/eslint-utils': 4.4.1(eslint@9.13.0)
+-       ci-info: 4.0.0
+-       clean-regexp: 1.0.0
+--      core-js-compat: 3.38.1
+-+      core-js-compat: 3.39.0
+-       eslint: 9.13.0
+-       esquery: 1.6.0
+-       globals: 15.11.0
+-@@ -4582,7 +4582,7 @@ snapshots:
+-   istanbul-lib-instrument@5.2.1:
+-     dependencies:
+-       '@babel/core': 7.26.0
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@istanbuljs/schema': 0.1.3
+-       istanbul-lib-coverage: 3.2.2
+-       semver: 6.3.1
+-@@ -4592,7 +4592,7 @@ snapshots:
+-   istanbul-lib-instrument@6.0.3:
+-     dependencies:
+-       '@babel/core': 7.26.0
+--      '@babel/parser': 7.26.1
+-+      '@babel/parser': 7.26.2
+-       '@istanbuljs/schema': 0.1.3
+-       istanbul-lib-coverage: 3.2.2
+-       semver: 7.6.3
+-@@ -4767,7 +4767,7 @@ snapshots:
+- 
+-   jest-message-util@29.7.0:
+-     dependencies:
+--      '@babel/code-frame': 7.26.0
+-+      '@babel/code-frame': 7.26.2
+-       '@jest/types': 29.6.3
+-       '@types/stack-utils': 2.0.3
+-       chalk: 4.1.2
+-@@ -4864,7 +4864,7 @@ snapshots:
+-   jest-snapshot@29.7.0:
+-     dependencies:
+-       '@babel/core': 7.26.0
+--      '@babel/generator': 7.26.0
+-+      '@babel/generator': 7.26.2
+-       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
+-       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
+-       '@babel/types': 7.26.0
+-@@ -5464,7 +5464,7 @@ snapshots:
+- 
+-   parse-json@5.2.0:
+-     dependencies:
+--      '@babel/code-frame': 7.26.0
+-+      '@babel/code-frame': 7.26.2
+-       error-ex: 1.3.2
+-       json-parse-even-better-errors: 2.3.1
+-       lines-and-columns: 1.2.4
+-@@ -5784,7 +5784,7 @@ snapshots:
+-     dependencies:
+-       eslint-visitor-keys: 3.4.3
+- 
+--  ts-api-utils@1.3.0(typescript@5.6.3):
+-+  ts-api-utils@1.4.0(typescript@5.6.3):
+-     dependencies:
+-       typescript: 5.6.3
+- 
+diff --git a/package.json b/package.json
+index 76cd376..a9501be 100644
+--- a/package.json
++++ b/package.json
+@@ -25,7 +25,7 @@
+     "@antfu/eslint-config": "^3.8.0",
+     "@types/jest": "^29.5.14",
+     "@types/js-yaml": "^4.0.9",
+-    "@types/node": "22.8.4",
++    "@types/node": "22.8.5",
+     "@typescript-eslint/eslint-plugin": "^8.12.2",
+     "@typescript-eslint/parser": "^8.12.2",
+     "aws-cdk": "2.164.1",
 diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 94085da..2e93e98 100644
+index 2e93e98..52e074a 100644
 --- a/pnpm-lock.yaml
 +++ b/pnpm-lock.yaml
-@@ -134,20 +134,20 @@ packages:
-       - jsonschema
-       - semver
+@@ -31,8 +31,8 @@ importers:
+         specifier: ^4.0.9
+         version: 4.0.9
+       '@types/node':
+-        specifier: 22.8.4
+-        version: 22.8.4
++        specifier: 22.8.5
++        version: 22.8.5
+       '@typescript-eslint/eslint-plugin':
+         specifier: ^8.12.2
+         version: 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
+@@ -50,13 +50,13 @@ importers:
+         version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
+       jest:
+         specifier: ^29.7.0
+-        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++        version: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       ts-jest:
+         specifier: ^29.2.5
+-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3)
++        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3)
+       ts-node:
+         specifier: ^10.9.2
+-        version: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
++        version: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
+       typescript:
+         specifier: ~5.6.3
+         version: 5.6.3
+@@ -573,8 +573,8 @@ packages:
+   '@types/ms@0.7.34':
+     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
  
--  '@babel/code-frame@7.26.0':
--    resolution: {integrity: sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==}
-+  '@babel/code-frame@7.26.2':
-+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-     engines: {node: '>=6.9.0'}
+-  '@types/node@22.8.4':
+-    resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
++  '@types/node@22.8.5':
++    resolution: {integrity: sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==}
  
--  '@babel/compat-data@7.26.0':
--    resolution: {integrity: sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==}
-+  '@babel/compat-data@7.26.2':
-+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
-     engines: {node: '>=6.9.0'}
+   '@types/normalize-package-data@2.4.4':
+     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+@@ -856,8 +856,8 @@ packages:
+     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+     engines: {node: '>=10'}
  
-   '@babel/core@7.26.0':
-     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
-     engines: {node: '>=6.9.0'}
+-  caniuse-lite@1.0.30001675:
+-    resolution: {integrity: sha512-/wV1bQwPrkLiQMjaJF5yUMVM/VdRPOCU8QZ+PmG6uW6DvYSrNY1bpwHI/3mOcUosLaJCzYDi5o91IQB51ft6cg==}
++  caniuse-lite@1.0.30001676:
++    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
  
--  '@babel/generator@7.26.0':
--    resolution: {integrity: sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==}
-+  '@babel/generator@7.26.2':
-+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
-     engines: {node: '>=6.9.0'}
- 
-   '@babel/helper-compilation-targets@7.25.9':
-@@ -184,8 +184,8 @@ packages:
-     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
-     engines: {node: '>=6.9.0'}
- 
--  '@babel/parser@7.26.1':
--    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
-+  '@babel/parser@7.26.2':
-+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
-     engines: {node: '>=6.0.0'}
-     hasBin: true
- 
-@@ -507,8 +507,8 @@ packages:
-   '@sinonjs/fake-timers@10.3.0':
-     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
- 
--  '@stylistic/eslint-plugin@2.9.0':
--    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
-+  '@stylistic/eslint-plugin@2.10.0':
-+    resolution: {integrity: sha512-neWEgjp0qKxutbrKac5g23V5LX2c2Clyiz3zFxxybY8VSMfr+MmvwM204zg8YFbe9n2zcTwkpppCL2luwYcMhg==}
-     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+   ccount@2.0.1:
+     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+@@ -1249,8 +1249,8 @@ packages:
      peerDependencies:
-       eslint: '>=8.40.0'
-@@ -922,8 +922,8 @@ packages:
-   convert-source-map@2.0.0:
-     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
  
--  core-js-compat@3.38.1:
--    resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
-+  core-js-compat@3.39.0:
-+    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
- 
-   create-jest@29.7.0:
-     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-@@ -2494,8 +2494,8 @@ packages:
-     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
-     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
- 
--  ts-api-utils@1.3.0:
--    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
-+  ts-api-utils@1.4.0:
-+    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
-     engines: {node: '>=16'}
+-  eslint-plugin-yml@1.14.0:
+-    resolution: {integrity: sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==}
++  eslint-plugin-yml@1.15.0:
++    resolution: {integrity: sha512-leC8APYVOsKyWUlvRwVhewytK5wS70BfMqIaUplFstRfzCoVp0YoEroV4cUEvQrBj93tQ3M9LcjO/ewr6D4kjA==}
+     engines: {node: ^14.17.0 || >=16.0.0}
      peerDependencies:
-       typescript: '>=4.2.0'
-@@ -2720,7 +2720,7 @@ snapshots:
-       '@clack/prompts': 0.7.0
-       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.13.0)
-       '@eslint/markdown': 6.2.1
--      '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0)(typescript@5.6.3)
-+      '@stylistic/eslint-plugin': 2.10.0(eslint@9.13.0)(typescript@5.6.3)
-       '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
-       '@typescript-eslint/parser': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
-       '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
-@@ -2775,23 +2775,23 @@ snapshots:
- 
-   '@aws-cdk/cloud-assembly-schema@38.0.1': {}
- 
--  '@babel/code-frame@7.26.0':
-+  '@babel/code-frame@7.26.2':
+       eslint: '>=6.0.0'
+@@ -2741,7 +2741,7 @@ snapshots:
+       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0)
+       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
+       eslint-plugin-vue: 9.30.0(eslint@9.13.0)
+-      eslint-plugin-yml: 1.14.0(eslint@9.13.0)
++      eslint-plugin-yml: 1.15.0(eslint@9.13.0)
+       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0)
+       globals: 15.11.0
+       jsonc-eslint-parser: 2.4.0
+@@ -3071,27 +3071,27 @@ snapshots:
+   '@jest/console@29.7.0':
      dependencies:
-       '@babel/helper-validator-identifier': 7.25.9
-       js-tokens: 4.0.0
-       picocolors: 1.1.1
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       jest-message-util: 29.7.0
+       jest-util: 29.7.0
+       slash: 3.0.0
  
--  '@babel/compat-data@7.26.0': {}
-+  '@babel/compat-data@7.26.2': {}
- 
-   '@babel/core@7.26.0':
+-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))':
++  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))':
      dependencies:
-       '@ampproject/remapping': 2.3.0
--      '@babel/code-frame': 7.26.0
--      '@babel/generator': 7.26.0
-+      '@babel/code-frame': 7.26.2
-+      '@babel/generator': 7.26.2
-       '@babel/helper-compilation-targets': 7.25.9
-       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
-       '@babel/helpers': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/template': 7.25.9
-       '@babel/traverse': 7.25.9
-       '@babel/types': 7.26.0
-@@ -2803,9 +2803,9 @@ snapshots:
+       '@jest/console': 29.7.0
+       '@jest/reporters': 29.7.0
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       ansi-escapes: 4.3.2
+       chalk: 4.1.2
+       ci-info: 3.9.0
+       exit: 0.1.2
+       graceful-fs: 4.2.11
+       jest-changed-files: 29.7.0
+-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-haste-map: 29.7.0
+       jest-message-util: 29.7.0
+       jest-regex-util: 29.6.3
+@@ -3116,7 +3116,7 @@ snapshots:
+     dependencies:
+       '@jest/fake-timers': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-mock: 29.7.0
+ 
+   '@jest/expect-utils@29.7.0':
+@@ -3134,7 +3134,7 @@ snapshots:
+     dependencies:
+       '@jest/types': 29.6.3
+       '@sinonjs/fake-timers': 10.3.0
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-message-util: 29.7.0
+       jest-mock: 29.7.0
+       jest-util: 29.7.0
+@@ -3156,7 +3156,7 @@ snapshots:
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+       '@jridgewell/trace-mapping': 0.3.25
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       collect-v8-coverage: 1.0.2
+       exit: 0.1.2
+@@ -3226,7 +3226,7 @@ snapshots:
+       '@jest/schemas': 29.6.3
+       '@types/istanbul-lib-coverage': 2.0.6
+       '@types/istanbul-reports': 3.0.4
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       '@types/yargs': 17.0.33
+       chalk: 4.1.2
+ 
+@@ -3327,7 +3327,7 @@ snapshots:
+ 
+   '@types/graceful-fs@4.1.9':
+     dependencies:
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+ 
+   '@types/istanbul-lib-coverage@2.0.6': {}
+ 
+@@ -3356,7 +3356,7 @@ snapshots:
+ 
+   '@types/ms@0.7.34': {}
+ 
+-  '@types/node@22.8.4':
++  '@types/node@22.8.5':
+     dependencies:
+       undici-types: 6.19.8
+ 
+@@ -3676,7 +3676,7 @@ snapshots:
+ 
+   browserslist@4.24.2:
+     dependencies:
+-      caniuse-lite: 1.0.30001675
++      caniuse-lite: 1.0.30001676
+       electron-to-chromium: 1.5.49
+       node-releases: 2.0.18
+       update-browserslist-db: 1.1.1(browserslist@4.24.2)
+@@ -3707,7 +3707,7 @@ snapshots:
+ 
+   camelcase@6.3.0: {}
+ 
+-  caniuse-lite@1.0.30001675: {}
++  caniuse-lite@1.0.30001676: {}
+ 
+   ccount@2.0.1: {}
+ 
+@@ -3760,13 +3760,13 @@ snapshots:
+     dependencies:
+       browserslist: 4.24.2
+ 
+-  create-jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  create-jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+       '@jest/types': 29.6.3
+       chalk: 4.1.2
+       exit: 0.1.2
+       graceful-fs: 4.2.11
+-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-util: 29.7.0
+       prompts: 2.4.2
+     transitivePeerDependencies:
+@@ -4177,7 +4177,7 @@ snapshots:
      transitivePeerDependencies:
        - supports-color
  
--  '@babel/generator@7.26.0':
-+  '@babel/generator@7.26.2':
+-  eslint-plugin-yml@1.14.0(eslint@9.13.0):
++  eslint-plugin-yml@1.15.0(eslint@9.13.0):
      dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
-       '@jridgewell/gen-mapping': 0.3.5
-       '@jridgewell/trace-mapping': 0.3.25
-@@ -2813,7 +2813,7 @@ snapshots:
- 
-   '@babel/helper-compilation-targets@7.25.9':
-     dependencies:
--      '@babel/compat-data': 7.26.0
-+      '@babel/compat-data': 7.26.2
-       '@babel/helper-validator-option': 7.25.9
-       browserslist: 4.24.2
-       lru-cache: 5.1.1
-@@ -2848,7 +2848,7 @@ snapshots:
-       '@babel/template': 7.25.9
-       '@babel/types': 7.26.0
- 
--  '@babel/parser@7.26.1':
-+  '@babel/parser@7.26.2':
-     dependencies:
-       '@babel/types': 7.26.0
- 
-@@ -2939,15 +2939,15 @@ snapshots:
- 
-   '@babel/template@7.25.9':
-     dependencies:
--      '@babel/code-frame': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/code-frame': 7.26.2
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
- 
-   '@babel/traverse@7.25.9':
-     dependencies:
--      '@babel/code-frame': 7.26.0
--      '@babel/generator': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/code-frame': 7.26.2
-+      '@babel/generator': 7.26.2
-+      '@babel/parser': 7.26.2
-       '@babel/template': 7.25.9
-       '@babel/types': 7.26.0
        debug: 4.3.7
-@@ -3278,7 +3278,7 @@ snapshots:
-     dependencies:
-       '@sinonjs/commons': 3.0.1
- 
--  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
-+  '@stylistic/eslint-plugin@2.10.0(eslint@9.13.0)(typescript@5.6.3)':
-     dependencies:
-       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
        eslint: 9.13.0
-@@ -3300,7 +3300,7 @@ snapshots:
- 
-   '@types/babel__core@7.20.5':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
-       '@types/babel__generator': 7.6.8
-       '@types/babel__template': 7.4.4
-@@ -3312,7 +3312,7 @@ snapshots:
- 
-   '@types/babel__template@7.4.4':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
- 
-   '@types/babel__traverse@7.20.6':
-@@ -3384,7 +3384,7 @@ snapshots:
-       graphemer: 1.4.0
-       ignore: 5.3.2
-       natural-compare: 1.4.0
--      ts-api-utils: 1.3.0(typescript@5.6.3)
-+      ts-api-utils: 1.4.0(typescript@5.6.3)
-     optionalDependencies:
-       typescript: 5.6.3
-     transitivePeerDependencies:
-@@ -3413,7 +3413,7 @@ snapshots:
-       '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
-       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
-       debug: 4.3.7
--      ts-api-utils: 1.3.0(typescript@5.6.3)
-+      ts-api-utils: 1.4.0(typescript@5.6.3)
-     optionalDependencies:
-       typescript: 5.6.3
-     transitivePeerDependencies:
-@@ -3431,7 +3431,7 @@ snapshots:
-       is-glob: 4.0.3
-       minimatch: 9.0.5
-       semver: 7.6.3
--      ts-api-utils: 1.3.0(typescript@5.6.3)
-+      ts-api-utils: 1.4.0(typescript@5.6.3)
-     optionalDependencies:
-       typescript: 5.6.3
-     transitivePeerDependencies:
-@@ -3462,7 +3462,7 @@ snapshots:
- 
-   '@vue/compiler-core@3.5.12':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@vue/shared': 3.5.12
-       entities: 4.5.0
-       estree-walker: 2.0.2
-@@ -3475,7 +3475,7 @@ snapshots:
- 
-   '@vue/compiler-sfc@3.5.12':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@vue/compiler-core': 3.5.12
-       '@vue/compiler-dom': 3.5.12
-       '@vue/compiler-ssr': 3.5.12
-@@ -3756,7 +3756,7 @@ snapshots:
- 
-   convert-source-map@2.0.0: {}
- 
--  core-js-compat@3.38.1:
-+  core-js-compat@3.39.0:
-     dependencies:
-       browserslist: 4.24.2
- 
-@@ -4143,7 +4143,7 @@ snapshots:
-       '@eslint-community/eslint-utils': 4.4.1(eslint@9.13.0)
-       ci-info: 4.0.0
-       clean-regexp: 1.0.0
--      core-js-compat: 3.38.1
-+      core-js-compat: 3.39.0
-       eslint: 9.13.0
-       esquery: 1.6.0
-       globals: 15.11.0
-@@ -4582,7 +4582,7 @@ snapshots:
-   istanbul-lib-instrument@5.2.1:
-     dependencies:
-       '@babel/core': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@istanbuljs/schema': 0.1.3
-       istanbul-lib-coverage: 3.2.2
-       semver: 6.3.1
-@@ -4592,7 +4592,7 @@ snapshots:
-   istanbul-lib-instrument@6.0.3:
-     dependencies:
-       '@babel/core': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@istanbuljs/schema': 0.1.3
-       istanbul-lib-coverage: 3.2.2
-       semver: 7.6.3
-@@ -4767,7 +4767,7 @@ snapshots:
- 
-   jest-message-util@29.7.0:
-     dependencies:
--      '@babel/code-frame': 7.26.0
-+      '@babel/code-frame': 7.26.2
+@@ -4637,7 +4637,7 @@ snapshots:
+       '@jest/expect': 29.7.0
+       '@jest/test-result': 29.7.0
        '@jest/types': 29.6.3
-       '@types/stack-utils': 2.0.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
        chalk: 4.1.2
-@@ -4864,7 +4864,7 @@ snapshots:
-   jest-snapshot@29.7.0:
+       co: 4.6.0
+       dedent: 1.5.3
+@@ -4657,16 +4657,16 @@ snapshots:
+       - babel-plugin-macros
+       - supports-color
+ 
+-  jest-cli@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  jest-cli@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+       chalk: 4.1.2
+-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      create-jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       exit: 0.1.2
+       import-local: 3.2.0
+-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-util: 29.7.0
+       jest-validate: 29.7.0
+       yargs: 17.7.2
+@@ -4676,7 +4676,7 @@ snapshots:
+       - supports-color
+       - ts-node
+ 
+-  jest-config@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  jest-config@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
      dependencies:
        '@babel/core': 7.26.0
--      '@babel/generator': 7.26.0
-+      '@babel/generator': 7.26.2
-       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
-       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-       '@babel/types': 7.26.0
-@@ -5464,7 +5464,7 @@ snapshots:
+       '@jest/test-sequencer': 29.7.0
+@@ -4701,8 +4701,8 @@ snapshots:
+       slash: 3.0.0
+       strip-json-comments: 3.1.1
+     optionalDependencies:
+-      '@types/node': 22.8.4
+-      ts-node: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
++      '@types/node': 22.8.5
++      ts-node: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
+     transitivePeerDependencies:
+       - babel-plugin-macros
+       - supports-color
+@@ -4731,7 +4731,7 @@ snapshots:
+       '@jest/environment': 29.7.0
+       '@jest/fake-timers': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-mock: 29.7.0
+       jest-util: 29.7.0
  
-   parse-json@5.2.0:
+@@ -4741,7 +4741,7 @@ snapshots:
      dependencies:
--      '@babel/code-frame': 7.26.0
-+      '@babel/code-frame': 7.26.2
-       error-ex: 1.3.2
-       json-parse-even-better-errors: 2.3.1
-       lines-and-columns: 1.2.4
-@@ -5784,7 +5784,7 @@ snapshots:
+       '@jest/types': 29.6.3
+       '@types/graceful-fs': 4.1.9
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       anymatch: 3.1.3
+       fb-watchman: 2.0.2
+       graceful-fs: 4.2.11
+@@ -4780,7 +4780,7 @@ snapshots:
+   jest-mock@29.7.0:
      dependencies:
-       eslint-visitor-keys: 3.4.3
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-util: 29.7.0
  
--  ts-api-utils@1.3.0(typescript@5.6.3):
-+  ts-api-utils@1.4.0(typescript@5.6.3):
+   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+@@ -4815,7 +4815,7 @@ snapshots:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       emittery: 0.13.1
+       graceful-fs: 4.2.11
+@@ -4843,7 +4843,7 @@ snapshots:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       cjs-module-lexer: 1.4.1
+       collect-v8-coverage: 1.0.2
+@@ -4889,7 +4889,7 @@ snapshots:
+   jest-util@29.7.0:
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       chalk: 4.1.2
+       ci-info: 3.9.0
+       graceful-fs: 4.2.11
+@@ -4908,7 +4908,7 @@ snapshots:
+     dependencies:
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       ansi-escapes: 4.3.2
+       chalk: 4.1.2
+       emittery: 0.13.1
+@@ -4917,17 +4917,17 @@ snapshots:
+ 
+   jest-worker@29.7.0:
+     dependencies:
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       jest-util: 29.7.0
+       merge-stream: 2.0.0
+       supports-color: 8.1.1
+ 
+-  jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
++  jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
+     dependencies:
+-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       '@jest/types': 29.6.3
+       import-local: 3.2.0
+-      jest-cli: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest-cli: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+     transitivePeerDependencies:
+       - '@types/node'
+       - babel-plugin-macros
+@@ -5788,12 +5788,12 @@ snapshots:
      dependencies:
        typescript: 5.6.3
  
+-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3):
++  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3):
+     dependencies:
+       bs-logger: 0.2.6
+       ejs: 3.1.10
+       fast-json-stable-stringify: 2.1.0
+-      jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
++      jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
+       jest-util: 29.7.0
+       json5: 2.2.3
+       lodash.memoize: 4.1.2
+@@ -5807,14 +5807,14 @@ snapshots:
+       '@jest/types': 29.6.3
+       babel-jest: 29.7.0(@babel/core@7.26.0)
+ 
+-  ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3):
++  ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3):
+     dependencies:
+       '@cspotcode/source-map-support': 0.8.1
+       '@tsconfig/node10': 1.0.11
+       '@tsconfig/node12': 1.0.11
+       '@tsconfig/node14': 1.0.3
+       '@tsconfig/node16': 1.0.4
+-      '@types/node': 22.8.4
++      '@types/node': 22.8.5
+       acorn: 8.14.0
+       acorn-walk: 8.3.4
+       arg: 4.1.3

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@antfu/eslint-config": "^3.8.0",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "22.8.4",
+    "@types/node": "22.8.5",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
     "aws-cdk": "2.164.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: 22.8.4
-        version: 22.8.4
+        specifier: 22.8.5
+        version: 22.8.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.12.2
         version: 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
@@ -50,13 +50,13 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+        version: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -573,8 +573,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@22.8.4':
-    resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
+  '@types/node@22.8.5':
+    resolution: {integrity: sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -856,8 +856,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001675:
-    resolution: {integrity: sha512-/wV1bQwPrkLiQMjaJF5yUMVM/VdRPOCU8QZ+PmG6uW6DvYSrNY1bpwHI/3mOcUosLaJCzYDi5o91IQB51ft6cg==}
+  caniuse-lite@1.0.30001676:
+    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1249,8 +1249,8 @@ packages:
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  eslint-plugin-yml@1.14.0:
-    resolution: {integrity: sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==}
+  eslint-plugin-yml@1.15.0:
+    resolution: {integrity: sha512-leC8APYVOsKyWUlvRwVhewytK5wS70BfMqIaUplFstRfzCoVp0YoEroV4cUEvQrBj93tQ3M9LcjO/ewr6D4kjA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -2741,7 +2741,7 @@ snapshots:
       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0)
       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       eslint-plugin-vue: 9.30.0(eslint@9.13.0)
-      eslint-plugin-yml: 1.14.0(eslint@9.13.0)
+      eslint-plugin-yml: 1.15.0(eslint@9.13.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0)
       globals: 15.11.0
       jsonc-eslint-parser: 2.4.0
@@ -3071,27 +3071,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3116,7 +3116,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3134,7 +3134,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3156,7 +3156,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3226,7 +3226,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3327,7 +3327,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3356,7 +3356,7 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@22.8.4':
+  '@types/node@22.8.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -3676,7 +3676,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001675
+      caniuse-lite: 1.0.30001676
       electron-to-chromium: 1.5.49
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -3707,7 +3707,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001675: {}
+  caniuse-lite@1.0.30001676: {}
 
   ccount@2.0.1: {}
 
@@ -3760,13 +3760,13 @@ snapshots:
     dependencies:
       browserslist: 4.24.2
 
-  create-jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4177,7 +4177,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-yml@1.14.0(eslint@9.13.0):
+  eslint-plugin-yml@1.15.0(eslint@9.13.0):
     dependencies:
       debug: 4.3.7
       eslint: 9.13.0
@@ -4637,7 +4637,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -4657,16 +4657,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4676,7 +4676,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -4701,8 +4701,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.8.4
-      ts-node: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+      '@types/node': 22.8.5
+      ts-node: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4731,7 +4731,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -4741,7 +4741,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4780,7 +4780,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -4815,7 +4815,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -4843,7 +4843,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -4889,7 +4889,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4908,7 +4908,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -4917,17 +4917,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5788,12 +5788,12 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -5807,14 +5807,14 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/diff.txt b/diff.txt
index 4f6a4a5..e69de29 100644
--- a/diff.txt
+++ b/diff.txt
@@ -1,308 +0,0 @@
-diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
-index 94085da..2e93e98 100644
---- a/pnpm-lock.yaml
-+++ b/pnpm-lock.yaml
-@@ -134,20 +134,20 @@ packages:
-       - jsonschema
-       - semver
- 
--  '@babel/code-frame@7.26.0':
--    resolution: {integrity: sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==}
-+  '@babel/code-frame@7.26.2':
-+    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
-     engines: {node: '>=6.9.0'}
- 
--  '@babel/compat-data@7.26.0':
--    resolution: {integrity: sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==}
-+  '@babel/compat-data@7.26.2':
-+    resolution: {integrity: sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==}
-     engines: {node: '>=6.9.0'}
- 
-   '@babel/core@7.26.0':
-     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
-     engines: {node: '>=6.9.0'}
- 
--  '@babel/generator@7.26.0':
--    resolution: {integrity: sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==}
-+  '@babel/generator@7.26.2':
-+    resolution: {integrity: sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==}
-     engines: {node: '>=6.9.0'}
- 
-   '@babel/helper-compilation-targets@7.25.9':
-@@ -184,8 +184,8 @@ packages:
-     resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
-     engines: {node: '>=6.9.0'}
- 
--  '@babel/parser@7.26.1':
--    resolution: {integrity: sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==}
-+  '@babel/parser@7.26.2':
-+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
-     engines: {node: '>=6.0.0'}
-     hasBin: true
- 
-@@ -507,8 +507,8 @@ packages:
-   '@sinonjs/fake-timers@10.3.0':
-     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
- 
--  '@stylistic/eslint-plugin@2.9.0':
--    resolution: {integrity: sha512-OrDyFAYjBT61122MIY1a3SfEgy3YCMgt2vL4eoPmvTwDBwyQhAXurxNQznlRD/jESNfYWfID8Ej+31LljvF7Xg==}
-+  '@stylistic/eslint-plugin@2.10.0':
-+    resolution: {integrity: sha512-neWEgjp0qKxutbrKac5g23V5LX2c2Clyiz3zFxxybY8VSMfr+MmvwM204zg8YFbe9n2zcTwkpppCL2luwYcMhg==}
-     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-     peerDependencies:
-       eslint: '>=8.40.0'
-@@ -922,8 +922,8 @@ packages:
-   convert-source-map@2.0.0:
-     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
- 
--  core-js-compat@3.38.1:
--    resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
-+  core-js-compat@3.39.0:
-+    resolution: {integrity: sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==}
- 
-   create-jest@29.7.0:
-     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-@@ -2494,8 +2494,8 @@ packages:
-     resolution: {integrity: sha512-khrZo4buq4qVmsGzS5yQjKe/WsFvV8fGfOjDQN0q4iy9FjRfPWRgTFrU8u1R2iu/SfWLhY9WnCi4Jhdrcbtg+g==}
-     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
- 
--  ts-api-utils@1.3.0:
--    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
-+  ts-api-utils@1.4.0:
-+    resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
-     engines: {node: '>=16'}
-     peerDependencies:
-       typescript: '>=4.2.0'
-@@ -2720,7 +2720,7 @@ snapshots:
-       '@clack/prompts': 0.7.0
-       '@eslint-community/eslint-plugin-eslint-comments': 4.4.1(eslint@9.13.0)
-       '@eslint/markdown': 6.2.1
--      '@stylistic/eslint-plugin': 2.9.0(eslint@9.13.0)(typescript@5.6.3)
-+      '@stylistic/eslint-plugin': 2.10.0(eslint@9.13.0)(typescript@5.6.3)
-       '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
-       '@typescript-eslint/parser': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
-       '@vitest/eslint-plugin': 1.1.7(@typescript-eslint/utils@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
-@@ -2775,23 +2775,23 @@ snapshots:
- 
-   '@aws-cdk/cloud-assembly-schema@38.0.1': {}
- 
--  '@babel/code-frame@7.26.0':
-+  '@babel/code-frame@7.26.2':
-     dependencies:
-       '@babel/helper-validator-identifier': 7.25.9
-       js-tokens: 4.0.0
-       picocolors: 1.1.1
- 
--  '@babel/compat-data@7.26.0': {}
-+  '@babel/compat-data@7.26.2': {}
- 
-   '@babel/core@7.26.0':
-     dependencies:
-       '@ampproject/remapping': 2.3.0
--      '@babel/code-frame': 7.26.0
--      '@babel/generator': 7.26.0
-+      '@babel/code-frame': 7.26.2
-+      '@babel/generator': 7.26.2
-       '@babel/helper-compilation-targets': 7.25.9
-       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
-       '@babel/helpers': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/template': 7.25.9
-       '@babel/traverse': 7.25.9
-       '@babel/types': 7.26.0
-@@ -2803,9 +2803,9 @@ snapshots:
-     transitivePeerDependencies:
-       - supports-color
- 
--  '@babel/generator@7.26.0':
-+  '@babel/generator@7.26.2':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
-       '@jridgewell/gen-mapping': 0.3.5
-       '@jridgewell/trace-mapping': 0.3.25
-@@ -2813,7 +2813,7 @@ snapshots:
- 
-   '@babel/helper-compilation-targets@7.25.9':
-     dependencies:
--      '@babel/compat-data': 7.26.0
-+      '@babel/compat-data': 7.26.2
-       '@babel/helper-validator-option': 7.25.9
-       browserslist: 4.24.2
-       lru-cache: 5.1.1
-@@ -2848,7 +2848,7 @@ snapshots:
-       '@babel/template': 7.25.9
-       '@babel/types': 7.26.0
- 
--  '@babel/parser@7.26.1':
-+  '@babel/parser@7.26.2':
-     dependencies:
-       '@babel/types': 7.26.0
- 
-@@ -2939,15 +2939,15 @@ snapshots:
- 
-   '@babel/template@7.25.9':
-     dependencies:
--      '@babel/code-frame': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/code-frame': 7.26.2
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
- 
-   '@babel/traverse@7.25.9':
-     dependencies:
--      '@babel/code-frame': 7.26.0
--      '@babel/generator': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/code-frame': 7.26.2
-+      '@babel/generator': 7.26.2
-+      '@babel/parser': 7.26.2
-       '@babel/template': 7.25.9
-       '@babel/types': 7.26.0
-       debug: 4.3.7
-@@ -3278,7 +3278,7 @@ snapshots:
-     dependencies:
-       '@sinonjs/commons': 3.0.1
- 
--  '@stylistic/eslint-plugin@2.9.0(eslint@9.13.0)(typescript@5.6.3)':
-+  '@stylistic/eslint-plugin@2.10.0(eslint@9.13.0)(typescript@5.6.3)':
-     dependencies:
-       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
-       eslint: 9.13.0
-@@ -3300,7 +3300,7 @@ snapshots:
- 
-   '@types/babel__core@7.20.5':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
-       '@types/babel__generator': 7.6.8
-       '@types/babel__template': 7.4.4
-@@ -3312,7 +3312,7 @@ snapshots:
- 
-   '@types/babel__template@7.4.4':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@babel/types': 7.26.0
- 
-   '@types/babel__traverse@7.20.6':
-@@ -3384,7 +3384,7 @@ snapshots:
-       graphemer: 1.4.0
-       ignore: 5.3.2
-       natural-compare: 1.4.0
--      ts-api-utils: 1.3.0(typescript@5.6.3)
-+      ts-api-utils: 1.4.0(typescript@5.6.3)
-     optionalDependencies:
-       typescript: 5.6.3
-     transitivePeerDependencies:
-@@ -3413,7 +3413,7 @@ snapshots:
-       '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
-       '@typescript-eslint/utils': 8.12.2(eslint@9.13.0)(typescript@5.6.3)
-       debug: 4.3.7
--      ts-api-utils: 1.3.0(typescript@5.6.3)
-+      ts-api-utils: 1.4.0(typescript@5.6.3)
-     optionalDependencies:
-       typescript: 5.6.3
-     transitivePeerDependencies:
-@@ -3431,7 +3431,7 @@ snapshots:
-       is-glob: 4.0.3
-       minimatch: 9.0.5
-       semver: 7.6.3
--      ts-api-utils: 1.3.0(typescript@5.6.3)
-+      ts-api-utils: 1.4.0(typescript@5.6.3)
-     optionalDependencies:
-       typescript: 5.6.3
-     transitivePeerDependencies:
-@@ -3462,7 +3462,7 @@ snapshots:
- 
-   '@vue/compiler-core@3.5.12':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@vue/shared': 3.5.12
-       entities: 4.5.0
-       estree-walker: 2.0.2
-@@ -3475,7 +3475,7 @@ snapshots:
- 
-   '@vue/compiler-sfc@3.5.12':
-     dependencies:
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@vue/compiler-core': 3.5.12
-       '@vue/compiler-dom': 3.5.12
-       '@vue/compiler-ssr': 3.5.12
-@@ -3756,7 +3756,7 @@ snapshots:
- 
-   convert-source-map@2.0.0: {}
- 
--  core-js-compat@3.38.1:
-+  core-js-compat@3.39.0:
-     dependencies:
-       browserslist: 4.24.2
- 
-@@ -4143,7 +4143,7 @@ snapshots:
-       '@eslint-community/eslint-utils': 4.4.1(eslint@9.13.0)
-       ci-info: 4.0.0
-       clean-regexp: 1.0.0
--      core-js-compat: 3.38.1
-+      core-js-compat: 3.39.0
-       eslint: 9.13.0
-       esquery: 1.6.0
-       globals: 15.11.0
-@@ -4582,7 +4582,7 @@ snapshots:
-   istanbul-lib-instrument@5.2.1:
-     dependencies:
-       '@babel/core': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@istanbuljs/schema': 0.1.3
-       istanbul-lib-coverage: 3.2.2
-       semver: 6.3.1
-@@ -4592,7 +4592,7 @@ snapshots:
-   istanbul-lib-instrument@6.0.3:
-     dependencies:
-       '@babel/core': 7.26.0
--      '@babel/parser': 7.26.1
-+      '@babel/parser': 7.26.2
-       '@istanbuljs/schema': 0.1.3
-       istanbul-lib-coverage: 3.2.2
-       semver: 7.6.3
-@@ -4767,7 +4767,7 @@ snapshots:
- 
-   jest-message-util@29.7.0:
-     dependencies:
--      '@babel/code-frame': 7.26.0
-+      '@babel/code-frame': 7.26.2
-       '@jest/types': 29.6.3
-       '@types/stack-utils': 2.0.3
-       chalk: 4.1.2
-@@ -4864,7 +4864,7 @@ snapshots:
-   jest-snapshot@29.7.0:
-     dependencies:
-       '@babel/core': 7.26.0
--      '@babel/generator': 7.26.0
-+      '@babel/generator': 7.26.2
-       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
-       '@babel/plugin-syntax-typescript': 7.25.9(@babel/core@7.26.0)
-       '@babel/types': 7.26.0
-@@ -5464,7 +5464,7 @@ snapshots:
- 
-   parse-json@5.2.0:
-     dependencies:
--      '@babel/code-frame': 7.26.0
-+      '@babel/code-frame': 7.26.2
-       error-ex: 1.3.2
-       json-parse-even-better-errors: 2.3.1
-       lines-and-columns: 1.2.4
-@@ -5784,7 +5784,7 @@ snapshots:
-     dependencies:
-       eslint-visitor-keys: 3.4.3
- 
--  ts-api-utils@1.3.0(typescript@5.6.3):
-+  ts-api-utils@1.4.0(typescript@5.6.3):
-     dependencies:
-       typescript: 5.6.3
- 
diff --git a/package.json b/package.json
index 76cd376..a9501be 100644
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@antfu/eslint-config": "^3.8.0",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "22.8.4",
+    "@types/node": "22.8.5",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
     "aws-cdk": "2.164.1",
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 2e93e98..52e074a 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: 22.8.4
-        version: 22.8.4
+        specifier: 22.8.5
+        version: 22.8.5
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.12.2
         version: 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3)
@@ -50,13 +50,13 @@ importers:
         version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+        version: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -573,8 +573,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@22.8.4':
-    resolution: {integrity: sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw==}
+  '@types/node@22.8.5':
+    resolution: {integrity: sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -856,8 +856,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001675:
-    resolution: {integrity: sha512-/wV1bQwPrkLiQMjaJF5yUMVM/VdRPOCU8QZ+PmG6uW6DvYSrNY1bpwHI/3mOcUosLaJCzYDi5o91IQB51ft6cg==}
+  caniuse-lite@1.0.30001676:
+    resolution: {integrity: sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1249,8 +1249,8 @@ packages:
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
 
-  eslint-plugin-yml@1.14.0:
-    resolution: {integrity: sha512-ESUpgYPOcAYQO9czugcX5OqRvn/ydDVwGCPXY4YjPqc09rHaUVUA6IE6HLQys4rXk/S+qx3EwTd1wHCwam/OWQ==}
+  eslint-plugin-yml@1.15.0:
+    resolution: {integrity: sha512-leC8APYVOsKyWUlvRwVhewytK5wS70BfMqIaUplFstRfzCoVp0YoEroV4cUEvQrBj93tQ3M9LcjO/ewr6D4kjA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -2741,7 +2741,7 @@ snapshots:
       eslint-plugin-unicorn: 56.0.0(eslint@9.13.0)
       eslint-plugin-unused-imports: 4.1.4(@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)(typescript@5.6.3))(eslint@9.13.0)
       eslint-plugin-vue: 9.30.0(eslint@9.13.0)
-      eslint-plugin-yml: 1.14.0(eslint@9.13.0)
+      eslint-plugin-yml: 1.15.0(eslint@9.13.0)
       eslint-processor-vue-blocks: 0.1.2(@vue/compiler-sfc@3.5.12)(eslint@9.13.0)
       globals: 15.11.0
       jsonc-eslint-parser: 2.4.0
@@ -3071,27 +3071,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3116,7 +3116,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3134,7 +3134,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3156,7 +3156,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3226,7 +3226,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3327,7 +3327,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3356,7 +3356,7 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@22.8.4':
+  '@types/node@22.8.5':
     dependencies:
       undici-types: 6.19.8
 
@@ -3676,7 +3676,7 @@ snapshots:
 
   browserslist@4.24.2:
     dependencies:
-      caniuse-lite: 1.0.30001675
+      caniuse-lite: 1.0.30001676
       electron-to-chromium: 1.5.49
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
@@ -3707,7 +3707,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001675: {}
+  caniuse-lite@1.0.30001676: {}
 
   ccount@2.0.1: {}
 
@@ -3760,13 +3760,13 @@ snapshots:
     dependencies:
       browserslist: 4.24.2
 
-  create-jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4177,7 +4177,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-yml@1.14.0(eslint@9.13.0):
+  eslint-plugin-yml@1.15.0(eslint@9.13.0):
     dependencies:
       debug: 4.3.7
       eslint: 9.13.0
@@ -4637,7 +4637,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -4657,16 +4657,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -4676,7 +4676,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -4701,8 +4701,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.8.4
-      ts-node: 10.9.2(@types/node@22.8.4)(typescript@5.6.3)
+      '@types/node': 22.8.5
+      ts-node: 10.9.2(@types/node@22.8.5)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -4731,7 +4731,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -4741,7 +4741,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -4780,7 +4780,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -4815,7 +4815,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -4843,7 +4843,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -4889,7 +4889,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -4908,7 +4908,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -4917,17 +4917,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5788,12 +5788,12 @@ snapshots:
     dependencies:
       typescript: 5.6.3
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.8.4)(ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.8.5)(ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -5807,14 +5807,14 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-node@10.9.2(@types/node@22.8.4)(typescript@5.6.3):
+  ts-node@10.9.2(@types/node@22.8.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.8.4
+      '@types/node': 22.8.5
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
```