### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
-    "aws-cdk": "2.173.0",
+    "aws-cdk": "2.173.1",
     "eslint": "^9.17.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
@@ -40,7 +40,7 @@
     "node": ">= 22.10.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.0",
+    "aws-cdk-lib": "2.173.1",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
     "source-map-support": "^0.5.21"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       aws-cdk-lib:
-        specifier: 2.173.0
-        version: 2.173.0(constructs@10.4.2)
+        specifier: 2.173.1
+        version: 2.173.1(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
@@ -40,8 +40,8 @@ importers:
         specifier: ^8.18.0
         version: 8.18.0(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.0
-        version: 2.173.0
+        specifier: 2.173.1
+        version: 2.173.1
       eslint:
         specifier: ^9.17.0
         version: 9.17.0
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.0:
-    resolution: {integrity: sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==}
+  aws-cdk-lib@2.173.1:
+    resolution: {integrity: sha512-xlbom4s3sbJDoHzIQmvunTufDQoJHQK8PTh653TE3338PysMX3liZ7efET9/FSQn50S2U3nINDGhrMvjkMBoKw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -767,8 +767,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.0:
-    resolution: {integrity: sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==}
+  aws-cdk@2.173.1:
+    resolution: {integrity: sha512-1KWz6ZPPpBk3LyxE+iR4Gi1bbdY5N6Zj7kx/26jqvavBfZle93vT3M0jlTKI6v/bBtpYsVHTOmPFcq0fg1DfCw==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -3657,7 +3657,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.0(constructs@10.4.2):
+  aws-cdk-lib@2.173.1(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.214
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -3665,7 +3665,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.0:
+  aws-cdk@2.173.1:
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Upgrades project dependencies. The following changes were made:
```diff
diff --git a/package.json b/package.json
index 9f13ad9..08e37c7 100644
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/node": "22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
-    "aws-cdk": "2.173.0",
+    "aws-cdk": "2.173.1",
     "eslint": "^9.17.0",
     "eslint-plugin-import": "^2.31.0",
     "jest": "^29.7.0",
@@ -40,7 +40,7 @@
     "node": ">= 22.10.0"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.173.0",
+    "aws-cdk-lib": "2.173.1",
     "constructs": "^10.4.2",
     "js-yaml": "^4.1.0",
     "source-map-support": "^0.5.21"
diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
index 83743c1..93a847c 100644
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       aws-cdk-lib:
-        specifier: 2.173.0
-        version: 2.173.0(constructs@10.4.2)
+        specifier: 2.173.1
+        version: 2.173.1(constructs@10.4.2)
       constructs:
         specifier: ^10.4.2
         version: 10.4.2
@@ -40,8 +40,8 @@ importers:
         specifier: ^8.18.0
         version: 8.18.0(eslint@9.17.0)(typescript@5.7.2)
       aws-cdk:
-        specifier: 2.173.0
-        version: 2.173.0
+        specifier: 2.173.1
+        version: 2.173.1
       eslint:
         specifier: ^9.17.0
         version: 9.17.0
@@ -749,8 +749,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.173.0:
-    resolution: {integrity: sha512-Da1JUwG8eL+chRSB+c2I4dRf54DWe/wmWKj9CBthNdsE9XCB8odyEcMpmgBC+R160o7ioYY2DBsAaKIIRa9XQw==}
+  aws-cdk-lib@2.173.1:
+    resolution: {integrity: sha512-xlbom4s3sbJDoHzIQmvunTufDQoJHQK8PTh653TE3338PysMX3liZ7efET9/FSQn50S2U3nINDGhrMvjkMBoKw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -767,8 +767,8 @@ packages:
       - yaml
       - mime-types
 
-  aws-cdk@2.173.0:
-    resolution: {integrity: sha512-riRGKSo5dzB0MSbdkZwXRC2t//dI220bgEUfVISilcEafBKj+BPzFBd/eNKuP/dEaS31njkCwtYrS7V7/lV4hQ==}
+  aws-cdk@2.173.1:
+    resolution: {integrity: sha512-1KWz6ZPPpBk3LyxE+iR4Gi1bbdY5N6Zj7kx/26jqvavBfZle93vT3M0jlTKI6v/bBtpYsVHTOmPFcq0fg1DfCw==}
     engines: {node: '>= 14.15.0'}
     hasBin: true
 
@@ -3657,7 +3657,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.173.0(constructs@10.4.2):
+  aws-cdk-lib@2.173.1(constructs@10.4.2):
     dependencies:
       '@aws-cdk/asset-awscli-v1': 2.2.214
       '@aws-cdk/asset-kubectl-v20': 2.1.3
@@ -3665,7 +3665,7 @@ snapshots:
       '@aws-cdk/cloud-assembly-schema': 38.0.1
       constructs: 10.4.2
 
-  aws-cdk@2.173.0:
+  aws-cdk@2.173.1:
     optionalDependencies:
       fsevents: 2.3.2
 
```